### PR TITLE
[#11755] 'Session closing soon' email: highlight 'No action is required if you have already submitted'

### DIFF
--- a/src/main/java/teammates/common/util/Templates.java
+++ b/src/main/java/teammates/common/util/Templates.java
@@ -52,6 +52,8 @@ public final class Templates {
                 FileHelper.readResourceFile("instructorEmailFragment-registrationKeyReset.html");
         public static final String USER_FEEDBACK_SESSION =
                 FileHelper.readResourceFile("userEmailTemplate-feedbackSession.html");
+        public static final String USER_FEEDBACK_SESSION_OPENING = 
+                FileHelper.readResourceFile("userEmailTemplate-feedbackSessionOpening.html");
         public static final String USER_FEEDBACK_SESSION_PUBLISHED =
                 FileHelper.readResourceFile("userEmailTemplate-feedbackSessionPublished.html");
         public static final String FRAGMENT_SESSION_LINKS_RECOVERY_ACCESS_LINKS_BY_SESSION =

--- a/src/main/java/teammates/common/util/Templates.java
+++ b/src/main/java/teammates/common/util/Templates.java
@@ -52,7 +52,7 @@ public final class Templates {
                 FileHelper.readResourceFile("instructorEmailFragment-registrationKeyReset.html");
         public static final String USER_FEEDBACK_SESSION =
                 FileHelper.readResourceFile("userEmailTemplate-feedbackSession.html");
-        public static final String USER_FEEDBACK_SESSION_OPENING = 
+        public static final String USER_FEEDBACK_SESSION_OPENING =
                 FileHelper.readResourceFile("userEmailTemplate-feedbackSessionOpening.html");
         public static final String USER_FEEDBACK_SESSION_PUBLISHED =
                 FileHelper.readResourceFile("userEmailTemplate-feedbackSessionPublished.html");

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -37,20 +37,21 @@ import teammates.logic.core.StudentsLogic;
  * @see EmailWrapper
  */
 public final class EmailGenerator {
-    // status-related strings
-    private static final String FEEDBACK_STATUS_SESSION_OPEN = "is still open for submissions,"
-                + " in case you have not submitted yet or wish to update your submission. "
-                + "<mark>No action is required if you have already submitted</mark>";
-    private static final String FEEDBACK_STATUS_SESSION_OPENING = "is now open";
-    private static final String FEEDBACK_STATUS_SESSION_CLOSING = "is closing soon";
-    private static final String FEEDBACK_STATUS_SESSION_CLOSED = "is now closed for submission";
-    private static final String FEEDBACK_STATUS_SESSION_OPENING_SOON = "is due to open soon";
-
     // feedback action strings
     private static final String FEEDBACK_ACTION_SUBMIT_EDIT_OR_VIEW = "submit, edit or view";
     private static final String FEEDBACK_ACTION_VIEW = "view";
-    private static final String HTML_NO_ACTION_REQUIRED =
-            "<p><mark>No action is required if you have already submitted.</mark></p>" + System.lineSeparator();
+    private static final String FEEDBACK_ACTION_SUBMIT_OR_UPDATE = ", in case you have not submitted yet or wish to update your submission. ";
+    private static final String HTML_NO_ACTION_REQUIRED = "<mark>No action is required if you have already submitted</mark>";
+
+    // status-related strings
+    private static final String FEEDBACK_STATUS_SESSION_OPEN = "is still open for submissions" 
+                                        + FEEDBACK_ACTION_SUBMIT_OR_UPDATE + HTML_NO_ACTION_REQUIRED;
+    private static final String FEEDBACK_STATUS_SESSION_OPENING = "is now open";
+    private static final String FEEDBACK_STATUS_SESSION_CLOSING = "is closing soon" 
+                                        + FEEDBACK_ACTION_SUBMIT_OR_UPDATE + HTML_NO_ACTION_REQUIRED;
+    private static final String FEEDBACK_STATUS_SESSION_CLOSED = "is now closed for submission";
+    private static final String FEEDBACK_STATUS_SESSION_OPENING_SOON = "is due to open soon";
+
 
     private static final String DATETIME_DISPLAY_FORMAT = "EEE, dd MMM yyyy, hh:mm a z";
 
@@ -700,10 +701,6 @@ public final class EmailGenerator {
             EmailType type, String feedbackAction) {
         StringBuilder studentAdditionalContactBuilder = new StringBuilder();
         StringBuilder instructorAdditionalContactBuilder = new StringBuilder();
-        if (type == EmailType.FEEDBACK_CLOSING) {
-            studentAdditionalContactBuilder.append(HTML_NO_ACTION_REQUIRED);
-            instructorAdditionalContactBuilder.append(HTML_NO_ACTION_REQUIRED);
-        }
         studentAdditionalContactBuilder.append(getAdditionalContactInformationFragment(course, false));
         instructorAdditionalContactBuilder.append(getAdditionalContactInformationFragment(course, true));
 

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -40,18 +40,18 @@ public final class EmailGenerator {
     // feedback action strings
     private static final String FEEDBACK_ACTION_SUBMIT_EDIT_OR_VIEW = "submit, edit or view";
     private static final String FEEDBACK_ACTION_VIEW = "view";
-    private static final String FEEDBACK_ACTION_SUBMIT_OR_UPDATE = ", in case you have not submitted yet or wish to update your submission. ";
+    private static final String FEEDBACK_ACTION_SUBMIT_OR_UPDATE =
+                            ", in case you have not submitted yet or wish to update your submission. ";
     private static final String HTML_NO_ACTION_REQUIRED = "<mark>No action is required if you have already submitted</mark>";
 
     // status-related strings
-    private static final String FEEDBACK_STATUS_SESSION_OPEN = "is still open for submissions" 
+    private static final String FEEDBACK_STATUS_SESSION_OPEN = "is still open for submissions"
                                         + FEEDBACK_ACTION_SUBMIT_OR_UPDATE + HTML_NO_ACTION_REQUIRED;
     private static final String FEEDBACK_STATUS_SESSION_OPENING = "is now open";
-    private static final String FEEDBACK_STATUS_SESSION_CLOSING = "is closing soon" 
+    private static final String FEEDBACK_STATUS_SESSION_CLOSING = "is closing soon"
                                         + FEEDBACK_ACTION_SUBMIT_OR_UPDATE + HTML_NO_ACTION_REQUIRED;
     private static final String FEEDBACK_STATUS_SESSION_CLOSED = "is now closed for submission";
     private static final String FEEDBACK_STATUS_SESSION_OPENING_SOON = "is due to open soon";
-
 
     private static final String DATETIME_DISPLAY_FORMAT = "EEE, dd MMM yyyy, hh:mm a z";
 

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -48,7 +48,7 @@ public final class EmailGenerator {
     private static final String FEEDBACK_ACTION_SUBMIT_EDIT_OR_VIEW = "submit, edit or view";
     private static final String FEEDBACK_ACTION_VIEW = "view";
     private static final String HTML_NO_ACTION_REQUIRED =
-            "<p>No action is required if you have already submitted.</p>" + System.lineSeparator();
+            "<p><mark>No action is required if you have already submitted.</mark></p>" + System.lineSeparator();
 
     private static final String DATETIME_DISPLAY_FORMAT = "EEE, dd MMM yyyy, hh:mm a z";
 

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -38,7 +38,8 @@ import teammates.logic.core.StudentsLogic;
  */
 public final class EmailGenerator {
     // status-related strings
-    private static final String FEEDBACK_STATUS_SESSION_OPEN = "is still open for submissions";
+    private static final String FEEDBACK_STATUS_SESSION_OPEN = "is still open for submissions," +
+                " in case you have not submitted yet or wish to update your submission";
     private static final String FEEDBACK_STATUS_SESSION_OPENING = "is now open";
     private static final String FEEDBACK_STATUS_SESSION_CLOSING = "is closing soon";
     private static final String FEEDBACK_STATUS_SESSION_CLOSED = "is now closed for submission";
@@ -107,7 +108,10 @@ public final class EmailGenerator {
                 ? FEEDBACK_STATUS_SESSION_OPENING
                 : FEEDBACK_STATUS_SESSION_CLOSING;
 
-        String template = EmailTemplates.USER_FEEDBACK_SESSION.replace("${status}", status);
+        String template = emailType == EmailType.FEEDBACK_OPENING
+                ? EmailTemplates.USER_FEEDBACK_SESSION_OPENING.replace("${status}", status)
+                : EmailTemplates.USER_FEEDBACK_SESSION.replace("${status}", status);
+
         return generateFeedbackSessionEmailBases(course, session, students, instructors, instructorsToNotify, template,
                 emailType, FEEDBACK_ACTION_SUBMIT_EDIT_OR_VIEW);
     }

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -38,8 +38,8 @@ import teammates.logic.core.StudentsLogic;
  */
 public final class EmailGenerator {
     // status-related strings
-    private static final String FEEDBACK_STATUS_SESSION_OPEN = "is still open for submissions," +
-                " in case you have not submitted yet or wish to update your submission";
+    private static final String FEEDBACK_STATUS_SESSION_OPEN = "is still open for submissions,"
+                + " in case you have not submitted yet or wish to update your submission";
     private static final String FEEDBACK_STATUS_SESSION_OPENING = "is now open";
     private static final String FEEDBACK_STATUS_SESSION_CLOSING = "is closing soon";
     private static final String FEEDBACK_STATUS_SESSION_CLOSED = "is now closed for submission";

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -39,7 +39,8 @@ import teammates.logic.core.StudentsLogic;
 public final class EmailGenerator {
     // status-related strings
     private static final String FEEDBACK_STATUS_SESSION_OPEN = "is still open for submissions,"
-                + " in case you have not submitted yet or wish to update your submission";
+                + " in case you have not submitted yet or wish to update your submission. "
+                + "<mark>No action is required if you have already submitted</mark>";
     private static final String FEEDBACK_STATUS_SESSION_OPENING = "is now open";
     private static final String FEEDBACK_STATUS_SESSION_CLOSING = "is closing soon";
     private static final String FEEDBACK_STATUS_SESSION_CLOSED = "is now closed for submission";
@@ -699,7 +700,7 @@ public final class EmailGenerator {
             EmailType type, String feedbackAction) {
         StringBuilder studentAdditionalContactBuilder = new StringBuilder();
         StringBuilder instructorAdditionalContactBuilder = new StringBuilder();
-        if (type == EmailType.FEEDBACK_CLOSING || type == EmailType.FEEDBACK_SESSION_REMINDER) {
+        if (type == EmailType.FEEDBACK_CLOSING) {
             studentAdditionalContactBuilder.append(HTML_NO_ACTION_REQUIRED);
             instructorAdditionalContactBuilder.append(HTML_NO_ACTION_REQUIRED);
         }

--- a/src/main/resources/userEmailTemplate-feedbackSessionOpening.html
+++ b/src/main/resources/userEmailTemplate-feedbackSessionOpening.html
@@ -3,7 +3,7 @@
 ${instructorPreamble}
 
 <p>
-  Just a gentle reminder that the following feedback session ${status}.
+  The following feedback session ${status}.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/main/resources/userEmailTemplate-feedbackSessionOpening.html
+++ b/src/main/resources/userEmailTemplate-feedbackSessionOpening.html
@@ -59,6 +59,9 @@ ${instructorPreamble}
     <li>
       The above link is unique to you. Please do not share it with others.
     </li>
+    <li>
+      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+    </li>
   </ul>
 </p>
 

--- a/src/test/java/teammates/logic/api/EmailGeneratorTest.java
+++ b/src/test/java/teammates/logic/api/EmailGeneratorTest.java
@@ -767,5 +767,4 @@ public class EmailGeneratorTest extends BaseLogicTest {
         }
         assertTrue(hasReceivedEmailCorrectly);
     }
-
 }

--- a/src/test/resources/emails/sessionClosingEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailCopyToInstructor.html
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  The following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionClosingEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailCopyToInstructor.html
@@ -66,7 +66,7 @@
   </ul>
 </p>
 
-<p>No action is required if you have already submitted.</p>
+<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/sessionClosingEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailCopyToInstructor.html
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  Just a gentle reminder that the following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon, in case you have not submitted yet or wish to update your submission. <mark>No action is required if you have already submitted</mark>.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>
@@ -69,7 +69,6 @@
   </ul>
 </p>
 
-<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/sessionClosingEmailForInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailForInstructor.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  Just a gentle reminder that the following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon, in case you have not submitted yet or wish to update your submission. <mark>No action is required if you have already submitted</mark>.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>
@@ -65,7 +65,6 @@
   </ul>
 </p>
 
-<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/sessionClosingEmailForInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailForInstructor.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  The following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionClosingEmailForInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailForInstructor.html
@@ -62,7 +62,7 @@
   </ul>
 </p>
 
-<p>No action is required if you have already submitted.</p>
+<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/sessionClosingEmailForInstructorWithExtension.html
+++ b/src/test/resources/emails/sessionClosingEmailForInstructorWithExtension.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  Just a gentle reminder that the following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon, in case you have not submitted yet or wish to update your submission. <mark>No action is required if you have already submitted</mark>.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>
@@ -65,7 +65,6 @@
   </ul>
 </p>
 
-<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/sessionClosingEmailForInstructorWithExtension.html
+++ b/src/test/resources/emails/sessionClosingEmailForInstructorWithExtension.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  The following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionClosingEmailForInstructorWithExtension.html
+++ b/src/test/resources/emails/sessionClosingEmailForInstructorWithExtension.html
@@ -62,7 +62,7 @@
   </ul>
 </p>
 
-<p>No action is required if you have already submitted.</p>
+<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/sessionClosingEmailForStudent.html
+++ b/src/test/resources/emails/sessionClosingEmailForStudent.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  Just a gentle reminder that the following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon, in case you have not submitted yet or wish to update your submission. <mark>No action is required if you have already submitted</mark>.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>
@@ -65,7 +65,6 @@
   </ul>
 </p>
 
-<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/sessionClosingEmailForStudent.html
+++ b/src/test/resources/emails/sessionClosingEmailForStudent.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  The following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionClosingEmailForStudent.html
+++ b/src/test/resources/emails/sessionClosingEmailForStudent.html
@@ -62,7 +62,7 @@
   </ul>
 </p>
 
-<p>No action is required if you have already submitted.</p>
+<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/sessionClosingEmailForStudentWithExtension.html
+++ b/src/test/resources/emails/sessionClosingEmailForStudentWithExtension.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  Just a gentle reminder that the following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon, in case you have not submitted yet or wish to update your submission. <mark>No action is required if you have already submitted</mark>.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>
@@ -65,7 +65,6 @@
   </ul>
 </p>
 
-<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/sessionClosingEmailForStudentWithExtension.html
+++ b/src/test/resources/emails/sessionClosingEmailForStudentWithExtension.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  The following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionClosingEmailForStudentWithExtension.html
+++ b/src/test/resources/emails/sessionClosingEmailForStudentWithExtension.html
@@ -62,7 +62,7 @@
   </ul>
 </p>
 
-<p>No action is required if you have already submitted.</p>
+<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/sessionClosingEmailTestingSanitizationCopyToInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailTestingSanitizationCopyToInstructor.html
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  The following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionClosingEmailTestingSanitizationCopyToInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailTestingSanitizationCopyToInstructor.html
@@ -66,7 +66,7 @@
   </ul>
 </p>
 
-<p>No action is required if you have already submitted.</p>
+<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/sessionClosingEmailTestingSanitizationCopyToInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailTestingSanitizationCopyToInstructor.html
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  Just a gentle reminder that the following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon, in case you have not submitted yet or wish to update your submission. <mark>No action is required if you have already submitted</mark>.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>
@@ -69,7 +69,6 @@
   </ul>
 </p>
 
-<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/sessionClosingEmailTestingSanitizationForStudent.html
+++ b/src/test/resources/emails/sessionClosingEmailTestingSanitizationForStudent.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  Just a gentle reminder that the following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon, in case you have not submitted yet or wish to update your submission. <mark>No action is required if you have already submitted</mark>.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>
@@ -65,7 +65,6 @@
   </ul>
 </p>
 
-<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/sessionClosingEmailTestingSanitizationForStudent.html
+++ b/src/test/resources/emails/sessionClosingEmailTestingSanitizationForStudent.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  The following feedback session is closing soon.
+  Just a gentle reminder that the following feedback session is closing soon.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionClosingEmailTestingSanitizationForStudent.html
+++ b/src/test/resources/emails/sessionClosingEmailTestingSanitizationForStudent.html
@@ -62,7 +62,7 @@
   </ul>
 </p>
 
-<p>No action is required if you have already submitted.</p>
+<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  Just a gentle reminder that the following feedback session is still open for submissions, in case you have not submitted yet or wish to update your submission.
+  Just a gentle reminder that the following feedback session is still open for submissions, in case you have not submitted yet or wish to update your submission. <mark>No action is required if you have already submitted</mark>.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>
@@ -69,7 +69,6 @@
   </ul>
 </p>
 
-<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  The following feedback session is still open for submissions.
+  Just a gentle reminder that the following feedback session is still open for submissions, in case you have not submitted yet or wish to update your submission.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
@@ -66,7 +66,7 @@
   </ul>
 </p>
 
-<p>No action is required if you have already submitted.</p>
+<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/sessionReminderEmailForInstructor.html
+++ b/src/test/resources/emails/sessionReminderEmailForInstructor.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  Just a gentle reminder that the following feedback session is still open for submissions, in case you have not submitted yet or wish to update your submission.
+  Just a gentle reminder that the following feedback session is still open for submissions, in case you have not submitted yet or wish to update your submission. <mark>No action is required if you have already submitted</mark>.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>
@@ -65,7 +65,6 @@
   </ul>
 </p>
 
-<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/sessionReminderEmailForInstructor.html
+++ b/src/test/resources/emails/sessionReminderEmailForInstructor.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  The following feedback session is still open for submissions.
+  Just a gentle reminder that the following feedback session is still open for submissions, in case you have not submitted yet or wish to update your submission.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionReminderEmailForInstructor.html
+++ b/src/test/resources/emails/sessionReminderEmailForInstructor.html
@@ -62,7 +62,7 @@
   </ul>
 </p>
 
-<p>No action is required if you have already submitted.</p>
+<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/sessionReminderEmailForStudent.html
+++ b/src/test/resources/emails/sessionReminderEmailForStudent.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  Just a gentle reminder that the following feedback session is still open for submissions, in case you have not submitted yet or wish to update your submission.
+  Just a gentle reminder that the following feedback session is still open for submissions, in case you have not submitted yet or wish to update your submission. <mark>No action is required if you have already submitted</mark>.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>
@@ -65,7 +65,6 @@
   </ul>
 </p>
 
-<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/sessionReminderEmailForStudent.html
+++ b/src/test/resources/emails/sessionReminderEmailForStudent.html
@@ -3,7 +3,7 @@
 
 
 <p>
-  The following feedback session is still open for submissions.
+  Just a gentle reminder that the following feedback session is still open for submissions, in case you have not submitted yet or wish to update your submission.
   <div>
     <table style="max-width:600px;border:1px solid black;">
       <tr>

--- a/src/test/resources/emails/sessionReminderEmailForStudent.html
+++ b/src/test/resources/emails/sessionReminderEmailForStudent.html
@@ -62,7 +62,7 @@
   </ul>
 </p>
 
-<p>No action is required if you have already submitted.</p>
+<p><mark>No action is required if you have already submitted.</mark></p>
 <p>
   <ul>
     <li>


### PR DESCRIPTION
Fixes #11755

**Outline of Solution**

Change `EmailGenarator.java` HTML_NO_ACTION_REQUIRED variable from 
`"<p>No action is required if you have already submitted.</p>" + System.lineSeparator();` 
to:
`"<p><mark>No action is required if you have already submitted.</mark></p>" + System.lineSeparator();`

Tweak phrasing in `userEmailTemplate-feedbackSession.html` from 
`The following feedback session ${status}.`
to:
`Just a gentle reminder that the following feedback session ${status}.`

Updated changes in **src/test/resources/emails/** to pass test cases

**Original email:**
![image](https://user-images.githubusercontent.com/57551677/177283445-afcb0965-9f39-444a-9100-fa504ae6e9cb.png)

**Modified email:**
![image](https://user-images.githubusercontent.com/57551677/177283525-d220bec3-a73b-4e7f-8b66-9226d2244fc7.png)
